### PR TITLE
fix: remove universal io

### DIFF
--- a/my_cli/test/src/commands/update_command_test.dart
+++ b/my_cli/test/src/commands/update_command_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:my_cli/src/command_runner.dart';
@@ -5,7 +7,6 @@ import 'package:my_cli/src/commands/commands.dart';
 import 'package:my_cli/src/version.dart';
 import 'package:pub_updater/pub_updater.dart';
 import 'package:test/test.dart';
-import 'package:universal_io/io.dart';
 
 class FakeProcessResult extends Fake implements ProcessResult {}
 


### PR DESCRIPTION

## Description

Universal IO is no longer a transitive dependency for the template.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
