### PR TITLE
fix: update silently fails when the sdk doesnt support most recent version

### DIFF
--- a/src/my_cli/lib/src/commands/update_command.dart
+++ b/src/my_cli/lib/src/commands/update_command.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:my_cli/src/command_runner.dart';
@@ -46,13 +48,24 @@ class UpdateCommand extends Command<int> {
     }
 
     final updateProgress = _logger.progress('Updating to $latestVersion');
+    late ProcessResult result;
     try {
-      await _pubUpdater.update(packageName: packageName);
+      result = await _pubUpdater.update(
+        packageName: packageName,
+        versionConstraint: latestVersion,
+      );
     } catch (error) {
       updateProgress.fail();
       _logger.err('$error');
       return ExitCode.software.code;
     }
+
+    if (result.exitCode != ExitCode.success.code) {
+      updateProgress.fail();
+      _logger.err('Error updating Very Good CLI: ${result.stderr}');
+      return ExitCode.software.code;
+    }
+
     updateProgress.complete('Updated to $latestVersion');
 
     return ExitCode.success.code;

--- a/src/my_cli/pubspec.yaml
+++ b/src/my_cli/pubspec.yaml
@@ -9,7 +9,9 @@ environment:
 dependencies:
   args: ^2.3.1
   mason_logger: ^0.2.0
-  pub_updater: ^0.2.1
+  pub_updater:
+    git:
+      url: https://github.com/VeryGoodOpenSource/pub_updater
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/src/my_cli/pubspec.yaml
+++ b/src/my_cli/pubspec.yaml
@@ -9,9 +9,7 @@ environment:
 dependencies:
   args: ^2.3.1
   mason_logger: ^0.2.0
-  pub_updater:
-    git:
-      url: https://github.com/VeryGoodOpenSource/pub_updater
+  pub_updater: ^0.2.4
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/src/my_cli/test/src/command_runner_test.dart
+++ b/src/my_cli/test/src/command_runner_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';
@@ -6,11 +8,13 @@ import 'package:my_cli/src/version.dart';
 import 'package:pub_updater/pub_updater.dart';
 import 'package:test/test.dart';
 
-import 'commands/update_command_test.dart';
-
 class MockLogger extends Mock implements Logger {}
 
 class MockPubUpdater extends Mock implements PubUpdater {}
+
+class MockProcessResult extends Mock implements ProcessResult {}
+
+class MockProgress extends Mock implements Progress {}
 
 const latestVersion = '0.0.0';
 
@@ -23,9 +27,11 @@ void main() {
     late PubUpdater pubUpdater;
     late Logger logger;
     late MyCLICommandRunner commandRunner;
+    late ProcessResult processResult;
 
     setUp(() {
       pubUpdater = MockPubUpdater();
+      processResult = MockProcessResult();
 
       when(
         () => pubUpdater.getLatestVersion(any()),
@@ -54,15 +60,18 @@ void main() {
         () => pubUpdater.getLatestVersion(any()),
       ).thenAnswer((_) async => latestVersion);
       when(
-        () => pubUpdater.update(packageName: packageName),
-      ).thenAnswer((_) => Future.value(FakeProcessResult()));
+        () => pubUpdater.update(
+          packageName: packageName,
+          versionConstraint: any(named: 'versionConstraint'),
+        ),
+      ).thenAnswer((_) => Future.value(processResult));
       when(
         () => pubUpdater.isUpToDate(
           packageName: any(named: 'packageName'),
           currentVersion: any(named: 'currentVersion'),
         ),
       ).thenAnswer((_) => Future.value(true));
-
+      when(() => processResult.exitCode).thenReturn(0);
       final progress = MockProgress();
       final progressLogs = <String>[];
       when(() => progress.complete(any())).thenAnswer((_) {

--- a/src/my_cli/test/src/commands/update_command_test.dart
+++ b/src/my_cli/test/src/commands/update_command_test.dart
@@ -8,7 +8,7 @@ import 'package:my_cli/src/version.dart';
 import 'package:pub_updater/pub_updater.dart';
 import 'package:test/test.dart';
 
-class FakeProcessResult extends Fake implements ProcessResult {}
+class MockProcessResult extends Mock implements ProcessResult {}
 
 class MockLogger extends Mock implements Logger {}
 
@@ -66,7 +66,10 @@ void main() {
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(() => logger.err('Exception: oops'));
         verifyNever(
-          () => pubUpdater.update(packageName: any(named: 'packageName')),
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
         );
       },
     );
@@ -78,14 +81,62 @@ void main() {
           () => pubUpdater.getLatestVersion(any()),
         ).thenAnswer((_) async => latestVersion);
         when(
-          () => pubUpdater.update(packageName: any(named: 'packageName')),
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
         ).thenThrow(Exception('oops'));
         final result = await commandRunner.run(['update']);
         expect(result, equals(ExitCode.software.code));
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(() => logger.err('Exception: oops'));
         verify(
-          () => pubUpdater.update(packageName: any(named: 'packageName')),
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'handles pub update process errors',
+      () async {
+        final processResult = MockProcessResult();
+
+        when(
+          () => processResult.exitCode,
+        ).thenReturn(1);
+
+        when<dynamic>(
+          () => processResult.stderr,
+        ).thenReturn('Oh no! Installing this is not possible right now!');
+
+        when(
+          () => pubUpdater.getLatestVersion(any()),
+        ).thenAnswer((_) async => latestVersion);
+
+        when(
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
+        ).thenAnswer((_) => Future.value(processResult));
+
+        final result = await commandRunner.run(['update']);
+
+        expect(result, equals(ExitCode.software.code));
+        verify(() => logger.progress('Checking for updates')).called(1);
+        verify(
+          () => logger.err(
+            '''Error updating Very Good CLI: Oh no! Installing this is not possible right now!''',
+          ),
+        );
+        verify(
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
         ).called(1);
       },
     );
@@ -93,18 +144,28 @@ void main() {
     test(
       'updates when newer version exists',
       () async {
+        final processResult = MockProcessResult();
         when(
           () => pubUpdater.getLatestVersion(any()),
         ).thenAnswer((_) async => latestVersion);
         when(
-          () => pubUpdater.update(packageName: packageName),
-        ).thenAnswer((_) => Future.value(FakeProcessResult()));
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
+        ).thenAnswer((_) => Future.value(processResult));
+        when(() => processResult.exitCode).thenReturn(0);
         when(() => logger.progress(any())).thenReturn(MockProgress());
         final result = await commandRunner.run(['update']);
         expect(result, equals(ExitCode.success.code));
         verify(() => logger.progress('Checking for updates')).called(1);
         verify(() => logger.progress('Updating to $latestVersion')).called(1);
-        verify(() => pubUpdater.update(packageName: packageName)).called(1);
+        verify(
+          () => pubUpdater.update(
+            packageName: packageName,
+            versionConstraint: latestVersion,
+          ),
+        ).called(1);
       },
     );
 
@@ -121,7 +182,12 @@ void main() {
           () => logger.info('CLI is already at the latest version.'),
         ).called(1);
         verifyNever(() => logger.progress('Updating to $latestVersion'));
-        verifyNever(() => pubUpdater.update(packageName: packageName));
+        verifyNever(
+          () => pubUpdater.update(
+            packageName: any(named: 'packageName'),
+            versionConstraint: any(named: 'versionConstraint'),
+          ),
+        );
       },
     );
   });


### PR DESCRIPTION


<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

fix: update silently fails when the SDK doesn't support the most recent version fo the cli

depends on a new version of the pub updater: https://github.com/VeryGoodOpenSource/pub_updater/pull/37

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
